### PR TITLE
Refactored to drop Gets

### DIFF
--- a/cmd/m-check/m-check.go
+++ b/cmd/m-check/m-check.go
@@ -86,10 +86,10 @@ func main() {
 		fmt.Println("[+] Finding Repository")
 		myRepo.NewGithubConnection()
 
-		myRepo.GetGithubContents(context.Background(), remotepath, &FilesDownloadURL)
+		myRepo.GithubContents(context.Background(), remotepath, &FilesDownloadURL)
 
 		fmt.Println("[+] Saving All Documentation Found")
-		err := directory.CreateDirectory(directory.GetFilePathTemplate(basepath, myRepo.Owner, myRepo.RepoName))
+		err := directory.CreateDirectory(directory.FilePathTemplate(basepath, myRepo.Owner, myRepo.RepoName))
 		if err != nil {
 			log.Fatalf("An error occurred while making a new directory: %v\n", err)
 		}
@@ -98,7 +98,7 @@ func main() {
 	}
 
 	fmt.Println("[+] Gathering Filenames")
-	files := myRepo.GetFileNames(basepath)
+	files := myRepo.FileNames(basepath)
 
 	links := myRepo.ParseBatch(basepath, files)
 
@@ -107,7 +107,7 @@ func main() {
 
 	fmt.Printf("[+] Findings Are Saved To %s/output.txt", basepath)
 	for _, val := range webConnectionResponse {
-		directory.OutputToFile(directory.GetFilePathTemplate(basepath, myRepo.Owner, myRepo.RepoName), val)
+		directory.OutputToFile(directory.FilePathTemplate(basepath, myRepo.Owner, myRepo.RepoName), val)
 	}
 
 }

--- a/internal/platform/directory/directory.go
+++ b/internal/platform/directory/directory.go
@@ -20,8 +20,8 @@ func CreateDirectory(path string) error {
 	return err
 }
 
-// GetFilePathTemplate formats a filepath to be used for the creation of a new file.
-func GetFilePathTemplate(base string, owner string, repoName string) string {
+// FilePathTemplate formats a filepath to be used for the creation of a new file.
+func FilePathTemplate(base string, owner string, repoName string) string {
 	filePathTemplate := fmt.Sprintf("./%s/%s/%s/", base, owner, repoName)
 	return filePathTemplate
 }

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -38,10 +38,10 @@ type Repository struct {
 	client *github.Client
 }
 
-// GetGithubContents recursively looks through any directory within the Documentation folder
+// GithubContents recursively looks through any directory within the Documentation folder
 // of a repository and appends the FilesURL of a Markdown file to a slice of strings to be
 // downloaded later.
-func (r *Repository) GetGithubContents(ctx context.Context, path string, filesDownloadURL *[]string) {
+func (r *Repository) GithubContents(ctx context.Context, path string, filesDownloadURL *[]string) {
 
 	_, dirContents, _, err := r.client.Repositories.GetContents(ctx, r.Owner, r.RepoName, path, nil)
 	if err != nil {
@@ -54,7 +54,7 @@ func (r *Repository) GetGithubContents(ctx context.Context, path string, filesDo
 				*filesDownloadURL = append(*filesDownloadURL, element.GetDownloadURL())
 			}
 		case "dir":
-			r.GetGithubContents(ctx, element.GetPath(), filesDownloadURL)
+			r.GithubContents(ctx, element.GetPath(), filesDownloadURL)
 		}
 	}
 
@@ -106,7 +106,7 @@ func (r *Repository) FetchAndCreate(basepath string, fileURLS []string) error {
 		path := strings.ReplaceAll(u.Path, "/", ".")
 		pathFirstIndex := strings.Index(path, ".docs")
 
-		f, err := os.Create(directory.GetFilePathTemplate(basepath, r.Owner, r.RepoName) + path[pathFirstIndex+6:])
+		f, err := os.Create(directory.FilePathTemplate(basepath, r.Owner, r.RepoName) + path[pathFirstIndex+6:])
 		if err != nil {
 			log.Fatalf("Failed to create file: %v\n", err)
 		}
@@ -123,11 +123,11 @@ func (r *Repository) FetchAndCreate(basepath string, fileURLS []string) error {
 
 }
 
-// GetFileNames gathers all the downloaded files found within the docs
+// FileNames gathers all the downloaded files found within the docs
 // directory and stores them into the Files Slice.
-func (r *Repository) GetFileNames(basepath string) []string {
+func (r *Repository) FileNames(basepath string) []string {
 	var f []string
-	files, err := ioutil.ReadDir(directory.GetFilePathTemplate(basepath, r.Owner, r.RepoName))
+	files, err := ioutil.ReadDir(directory.FilePathTemplate(basepath, r.Owner, r.RepoName))
 
 	if err != nil {
 		log.Fatalf("Could not read files from directory: %v\n", err)
@@ -174,7 +174,7 @@ func (r *Repository) Parse(f io.Reader) []string {
 func (r *Repository) ParseFileHandler(basepath string, fileName string) []string {
 	var links []string
 	if filepath.Ext(fileName) == ".md" {
-		f, err := os.Open(directory.GetFilePathTemplate(basepath, r.Owner, r.RepoName) + fileName)
+		f, err := os.Open(directory.FilePathTemplate(basepath, r.Owner, r.RepoName) + fileName)
 		if err != nil {
 			log.Fatalf("Failed to open file: %v\n", err)
 		}


### PR DESCRIPTION
Refactored the code to remove the use of Gets in the method signature as it is bad-practice. https://golang.org/doc/effective_go#Getters