### PR TITLE
Changed the client to be passed as a pointer

### DIFF
--- a/cmd/m-check/m-check.go
+++ b/cmd/m-check/m-check.go
@@ -80,7 +80,7 @@ func main() {
 
 	myRepo := repo.NewRepository(owner, reponame, token)
 	client := http.Client{Timeout: 5 * time.Second}
-	checker := urlcheck.NewURLCheck(client)
+	checker := urlcheck.NewURLCheck(&client)
 	if local == false {
 
 		fmt.Println("[+] Finding Repository")

--- a/internal/urlcheck/urlcheck.go
+++ b/internal/urlcheck/urlcheck.go
@@ -19,9 +19,9 @@ type URLChecker struct {
 
 // NewURLCheck is a wrapper for the creation of a URLChecker type
 // which returns the address of the newly created URLChecker type.
-func NewURLCheck(client http.Client) *URLChecker {
+func NewURLCheck(client *http.Client) *URLChecker {
 	return &URLChecker{
-		client: client,
+		client: *client,
 	}
 }
 


### PR DESCRIPTION
Changed the client to be passed as a pointer instead of a value. This will reduce the amount of copies of client that are being created.